### PR TITLE
pc - add scaffolding for Slack Bot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,13 @@
 			<artifactId>javabean-tester</artifactId>
 			<version>1.0.0</version>
 		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/me.ramswaroop.jbot/jbot -->
+		<dependency>
+			<groupId>me.ramswaroop.jbot</groupId>
+			<artifactId>jbot</artifactId>
+			<version>3.0.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/secrets-heroku.properties.SAMPLE
+++ b/secrets-heroku.properties.SAMPLE
@@ -5,6 +5,9 @@ app.member.hosted-domain=ucsb.edu
 auth0.domain=FILL-IT-IN
 auth0.clientId=FILL-IT-IN
 
+app.slack.slashCommandToken=FILL-IT-IN
+
+
 security.oauth2.resource.id=${app.namespace}/api
 security.oauth2.resource.jwk.keySetUri=https://${auth0.domain}/.well-known/jwks.json
 

--- a/secrets-localhost.properties.SAMPLE
+++ b/secrets-localhost.properties.SAMPLE
@@ -2,6 +2,8 @@ app.namespace=https://NAME-OF-YOUR-APP.herokuapp.com
 app.admin.emails=phtcon@ucsb.edu
 app.member.hosted-domain=ucsb.edu
 
+app.slack.slashCommandToken=FILL-IT-IN
+
 auth0.domain=FILL-IT-IN
 auth0.clientId=FILL-IT-IN
 

--- a/src/main/java/edu/ucsb/mapache/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/mapache/config/SecurityConfig.java
@@ -16,7 +16,7 @@ public class SecurityConfig extends ResourceServerConfigurerAdapter {
 
   @Override
   public void configure(HttpSecurity http) throws Exception {
-    http.authorizeRequests().mvcMatchers("/api/public").permitAll().mvcMatchers("/api/**").authenticated().anyRequest()
+    http.authorizeRequests().mvcMatchers("/api/public/**").permitAll().mvcMatchers("/api/**").authenticated().anyRequest()
         .permitAll();
   }
 

--- a/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
+++ b/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
@@ -1,0 +1,173 @@
+package edu.ucsb.mapache.controllers;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import me.ramswaroop.jbot.core.slack.models.Attachment;
+import me.ramswaroop.jbot.core.slack.models.RichMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import edu.ucsb.mapache.models.SlackSlashCommandParams;
+
+
+/**
+ * Sample Slash Command Handler.
+ *
+ * @author ramswaroop
+ * @version 1.0.0, 20/06/2016
+ */
+@RestController
+public class SlackSlashCommandController {
+
+    private static final Logger logger = LoggerFactory.getLogger(SlackSlashCommandController.class);
+
+    /**
+     * The token you get while creating a new Slash Command. You should paste the
+     * token in application.properties file.
+     */
+    @Value("${app.slack.slashCommandToken}")
+    private String slackToken;
+
+    /**
+     * Slash Command handler. When a user types for example "/app help" then slack
+     * sends a POST request to this endpoint. So, this endpoint should match the url
+     * you set while creating the Slack Slash Command.
+     *
+     * @param token
+     * @param teamId
+     * @param teamDomain
+     * @param channelId
+     * @param channelName
+     * @param userId
+     * @param userName
+     * @param command
+     * @param text
+     * @param responseUrl
+     * @return
+     */
+    @RequestMapping(value = "/api/public/slash-command", method = RequestMethod.POST, consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    public RichMessage onReceiveSlashCommand(@RequestParam("token") String token,
+            @RequestParam("team_id") String teamId, @RequestParam("team_domain") String teamDomain,
+            @RequestParam("channel_id") String channelId, @RequestParam("channel_name") String channelName,
+            @RequestParam("user_id") String userId, @RequestParam("user_name") String userName,
+            @RequestParam("command") String command, @RequestParam("text") String text,
+            @RequestParam("response_url") String responseUrl) {
+        // validate token
+        logger.info("slash command processing...");
+        if (!token.equals(slackToken)) {
+            return new RichMessage("Sorry: the slack bot received an invalid token.");
+        }
+
+        SlackSlashCommandParams params = new SlackSlashCommandParams();
+
+        params.setToken(token);
+        params.setTeamId(teamId);
+        params.setTeamDomain(teamDomain);
+        params.setChannelId(channelId);
+        params.setChannelName(channelName);
+        params.setUserId(userId);
+        params.setCommand(command);
+        params.setText(text);
+        params.setResponseUrl(responseUrl);
+
+        String textParts[] = params.getTextParts();
+
+        if (textParts.length <= 0 || textParts[0].equals("")) {
+            return emptyCommand(params);
+        }
+
+        String firstArg = textParts[0];
+
+        if (firstArg.equals("status")) {
+            return statusCommand(params);
+        }
+
+        if (firstArg.equals("time")) {
+            return timeCommand(params);
+        }
+
+        if (firstArg.equals("debug")) {
+            return debugCommand(params);
+        }
+
+        return unknownCommand(params);
+
+    }
+
+    public RichMessage unknownCommand(SlackSlashCommandParams params) {
+        RichMessage richMessage = new RichMessage(String.format("Sorry but %s doesn't know the command %s",
+                params.getCommand(), params.getTextParts()[0]));
+        richMessage.setResponseType("ephemeral");
+        return richMessage.encodedMessage(); // don't forget to send the encoded message to Slack
+    }
+
+    public RichMessage emptyCommand(SlackSlashCommandParams params) {
+        RichMessage richMessage = new RichMessage(
+                String.format("The %s bot knows these commands", params.getCommand()));
+
+        richMessage.setResponseType("ephemeral");
+
+        int numAttachments = 3;
+        Attachment[] attachments = new Attachment[numAttachments];
+        for (int i = 0; i < numAttachments; i++)
+            attachments[i] = new Attachment();
+        attachments[0].setText(String.format("%s status", params.getCommand()));
+        attachments[1].setText(String.format("%s time", params.getCommand()));
+        attachments[2].setText(String.format("%s debug", params.getCommand()));
+        richMessage.setAttachments(attachments);
+
+        return richMessage.encodedMessage(); // don't forget to send the encoded message to Slack
+    }
+
+    public RichMessage statusCommand(SlackSlashCommandParams params) {
+        RichMessage richMessage = new RichMessage(
+                String.format("From: %s Status is ok!", params.getCommand(), params.getTextParts()[0]));
+        richMessage.setResponseType("ephemeral");
+        return richMessage.encodedMessage(); // don't forget to send the encoded message to Slack
+    }
+
+    public RichMessage timeCommand(SlackSlashCommandParams params) {
+        String message = String.format("From: %s... the time on the server is %s", params.getCommand(), timeNow());
+        RichMessage richMessage = new RichMessage(message);
+        richMessage.setResponseType("ephemeral");
+        return richMessage.encodedMessage(); // don't forget to send the encoded message to Slack
+    }
+
+    public RichMessage debugCommand(SlackSlashCommandParams params) {
+        /** build response */
+        RichMessage richMessage = new RichMessage(String.format("Here is what %s knows:", params.getCommand()));
+        richMessage.setResponseType("in_channel"); // other option is "ephemeral"
+
+        // set attachments
+        int numAttachments = 8;
+        Attachment[] attachments = new Attachment[numAttachments];
+        for (int i = 0; i < numAttachments; i++)
+            attachments[i] = new Attachment();
+        attachments[0].setText(String.format("team_id=%s", params.getTeamId()));
+        attachments[1].setText(String.format("team_domain=%s", params.getTeamDomain()));
+        attachments[2].setText(String.format("channel_id=%s", params.getChannelId()));
+        attachments[3].setText(String.format("channel_name=%s", params.getChannelName()));
+        attachments[4].setText(String.format("user_id=%s", params.getUserId()));
+        attachments[5].setText(String.format("user_name=%s", params.getUserName()));
+        attachments[6].setText(String.format("command=%s", params.getCommand()));
+        attachments[7].setText(String.format("text=%s", params.getText()));
+
+        richMessage.setAttachments(attachments);
+
+        return richMessage.encodedMessage(); // don't forget to send the encoded message to Slack
+    }
+
+    private String timeNow() {
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd 'at' HH:mm:ss z");
+        Date date = new Date(System.currentTimeMillis());
+        return formatter.format(date);
+    }
+
+}

--- a/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
+++ b/src/main/java/edu/ucsb/mapache/controllers/SlackSlashCommandController.java
@@ -7,6 +7,7 @@ import me.ramswaroop.jbot.core.slack.models.Attachment;
 import me.ramswaroop.jbot.core.slack.models.RichMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import edu.ucsb.mapache.models.SlackSlashCommandParams;
+import edu.ucsb.mapache.repositories.ChannelRepository;
 
 
 /**
@@ -27,6 +29,9 @@ import edu.ucsb.mapache.models.SlackSlashCommandParams;
 public class SlackSlashCommandController {
 
     private static final Logger logger = LoggerFactory.getLogger(SlackSlashCommandController.class);
+
+    @Autowired
+    ChannelRepository channelRepository;
 
     /**
      * The token you get while creating a new Slash Command. You should paste the
@@ -130,6 +135,17 @@ public class SlackSlashCommandController {
         RichMessage richMessage = new RichMessage(
                 String.format("From: %s Status is ok!", params.getCommand(), params.getTextParts()[0]));
         richMessage.setResponseType("ephemeral");
+
+        // TODO: Go through the list of channels, and find out how many channels
+        // have the word "team" in the name of the channel
+
+        // To get all of the channels, you can do this:
+        //   Iterable<Channel> channels = channelRepository.findAll();
+        // then you can loop through and look at the channel names
+
+        // then perhaps add some "attachements" to the message before
+        // sending it back
+        
         return richMessage.encodedMessage(); // don't forget to send the encoded message to Slack
     }
 

--- a/src/main/java/edu/ucsb/mapache/models/SlackSlashCommandParams.java
+++ b/src/main/java/edu/ucsb/mapache/models/SlackSlashCommandParams.java
@@ -1,0 +1,138 @@
+package edu.ucsb.mapache.models;
+
+import java.util.Objects;
+
+public class SlackSlashCommandParams {
+    private String token;
+    private String teamId;
+    private String teamDomain;
+    private String channelId;
+    private String channelName;
+    private String userId;
+    private String userName;
+    private String command;
+    private String text;
+    private String responseUrl;
+
+    public SlackSlashCommandParams() {
+    }
+
+    public String getToken() {
+        return this.token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public String getTeamId() {
+        return this.teamId;
+    }
+
+    public void setTeamId(String teamId) {
+        this.teamId = teamId;
+    }
+
+    public String getTeamDomain() {
+        return this.teamDomain;
+    }
+
+    public void setTeamDomain(String teamDomain) {
+        this.teamDomain = teamDomain;
+    }
+
+    public String getChannelId() {
+        return this.channelId;
+    }
+
+    public void setChannelId(String channelId) {
+        this.channelId = channelId;
+    }
+
+    public String getChannelName() {
+        return this.channelName;
+    }
+
+    public void setChannelName(String channelName) {
+        this.channelName = channelName;
+    }
+
+    public String getUserId() {
+        return this.userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getUserName() {
+        return this.userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getCommand() {
+        return this.command;
+    }
+
+    public void setCommand(String command) {
+        this.command = command;
+    }
+
+    public String getText() {
+        return this.text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public String getResponseUrl() {
+        return this.responseUrl;
+    }
+
+    public void setResponseUrl(String responseUrl) {
+        this.responseUrl = responseUrl;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this)
+            return true;
+        if (!(o instanceof SlackSlashCommandParams)) {
+            return false;
+        }
+        SlackSlashCommandParams SlackSlashCommandParams = (SlackSlashCommandParams) o;
+        return Objects.equals(token, SlackSlashCommandParams.token) && Objects.equals(teamId, SlackSlashCommandParams.teamId)
+                && Objects.equals(teamDomain, SlackSlashCommandParams.teamDomain)
+                && Objects.equals(channelId, SlackSlashCommandParams.channelId)
+                && Objects.equals(channelName, SlackSlashCommandParams.channelName)
+                && Objects.equals(userId, SlackSlashCommandParams.userId)
+                && Objects.equals(userName, SlackSlashCommandParams.userName)
+                && Objects.equals(command, SlackSlashCommandParams.command) && Objects.equals(text, SlackSlashCommandParams.text)
+                && Objects.equals(responseUrl, SlackSlashCommandParams.responseUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(token, teamId, teamDomain, channelId, channelName, userId, userName, command, text,
+                responseUrl);
+    }
+
+    @Override
+    public String toString() {
+        return "{" + " token='" + getToken() + "'" + ", teamId='" + getTeamId() + "'" + ", teamDomain='"
+                + getTeamDomain() + "'" + ", channelId='" + getChannelId() + "'" + ", channelName='" + getChannelName()
+                + "'" + ", userId='" + getUserId() + "'" + ", userName='" + getUserName() + "'" + ", command='"
+                + getCommand() + "'" + ", text='" + getText() + "'" + ", responseUrl='" + getResponseUrl() + "'" + "}";
+    }
+
+    // For explanation of "[\\s\\p{Z}]" see: https://stackoverflow.com/a/26713907
+    public String [] getTextParts() {
+        String textParts[]= this.text.split("[\\s\\p{Z}]");
+        return textParts;
+    }
+
+}

--- a/src/main/java/edu/ucsb/mapache/models/SlackSlashCommandParams.java
+++ b/src/main/java/edu/ucsb/mapache/models/SlackSlashCommandParams.java
@@ -131,7 +131,7 @@ public class SlackSlashCommandParams {
 
     // For explanation of "[\\s\\p{Z}]" see: https://stackoverflow.com/a/26713907
     public String [] getTextParts() {
-        String textParts[]= this.text.split("[\\s\\p{Z}]");
+        String textParts[]= this.text.split("[\\s\\p{Z}]+");
         return textParts;
     }
 

--- a/src/test/java/edu/ucsb/mapache/controllers/SlackSlashCommandControllerTests.java
+++ b/src/test/java/edu/ucsb/mapache/controllers/SlackSlashCommandControllerTests.java
@@ -1,0 +1,38 @@
+package edu.ucsb.mapache.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.mapache.config.SecurityConfig;
+import edu.ucsb.mapache.repositories.ChannelRepository;
+
+
+@WebMvcTest(value = SlackSlashCommandController.class)
+@Import(SecurityConfig.class)
+public class SlackSlashCommandControllerTests {
+  
+  @Autowired
+  private MockMvc mockMvc;
+  
+  @MockBean
+  ChannelRepository channelRepository;
+
+  private final String URL="/api/public/slash-command";
+  
+  @Test
+  public void test_postSlashMessage() throws Exception {
+    mockMvc
+        .perform(post(URL))
+        .andExpect(status().is(200));
+  }
+
+}

--- a/src/test/java/edu/ucsb/mapache/models/SlackSlashCommandParamsTests.java
+++ b/src/test/java/edu/ucsb/mapache/models/SlackSlashCommandParamsTests.java
@@ -31,28 +31,28 @@ public class SlackSlashCommandParamsTests {
 
     @Test
     public void test_equalsSelf() throws Exception {
-        SlackSlashCommandParams params = new SlackSlashCommandParams(1,10,10,new ArrayList<Course>());
+        SlackSlashCommandParams params = new SlackSlashCommandParams();
         assertEquals(params, params);
     }
 
     @Test
     public void test_equalsAnother() throws Exception {
-        SlackSlashCommandParams params1 = new SlackSlashCommandParams(1,10,10,new ArrayList<Course>());
-        SlackSlashCommandParams params2 = new SlackSlashCommandParams(1,10,10,new ArrayList<Course>());
+        SlackSlashCommandParams params1 = new SlackSlashCommandParams();
+        SlackSlashCommandParams params2 = new SlackSlashCommandParams();
         assertEquals(params1, params2);
     }
 
     @Test
     public void test_hashCode() throws Exception {
-        SlackSlashCommandParams params1 = new SlackSlashCommandParams(1,10,10,new ArrayList<Course>());
-        SlackSlashCommandParams params2 = new SlackSlashCommandParams(1,10,10,new ArrayList<Course>());
+        SlackSlashCommandParams params1 = new SlackSlashCommandParams();
+        SlackSlashCommandParams params2 = new SlackSlashCommandParams();
         assertEquals(params1.hashCode(), params2.hashCode());
     }
 
-    @Test
-    public void test_toString() throws Exception {
-        SlackSlashCommandParams params1 = new SlackSlashCommandParams(1,10,10,new ArrayList<Course>());
-        assertEquals("{ pageNumber='1', pageSize='10', total='10', classes='[]'}",params1.toString());
-    }
+    // @Test
+    // public void test_toString() throws Exception {
+    //     SlackSlashCommandParams params1 = new SlackSlashCommandParams(1,10,10,new ArrayList<Course>());
+    //     assertEquals("{ pageNumber='1', pageSize='10', total='10', classes='[]'}",params1.toString());
+    // }
 
 }

--- a/src/test/java/edu/ucsb/mapache/models/SlackSlashCommandParamsTests.java
+++ b/src/test/java/edu/ucsb/mapache/models/SlackSlashCommandParamsTests.java
@@ -1,0 +1,58 @@
+package edu.ucsb.mapache.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import org.junit.jupiter.api.Test;
+
+import net.codebox.javabeantester.JavaBeanTester;
+
+
+public class SlackSlashCommandParamsTests {
+
+    @Test
+    public void testGettersAndSetters() throws Exception {
+        // See: https://github.com/codebox/javabean-tester
+        // The classes that should NOT be tested with the Bean are the
+        // ones that set and get List<> instances
+        JavaBeanTester.test(SlackSlashCommandParams.class,"textParts");
+    }
+  
+    @Test
+    public void test_getTextParts() {
+        SlackSlashCommandParams params = new SlackSlashCommandParams();
+        params.setText("a b   c  \t d");
+        String [] result = params.getTextParts();
+        assertEquals(4, result.length);
+        assertEquals("a",result[0]);
+        assertEquals("b",result[1]);
+        assertEquals("c",result[2]);
+        assertEquals("d",result[3]);
+    }
+
+    @Test
+    public void test_equalsSelf() throws Exception {
+        SlackSlashCommandParams params = new SlackSlashCommandParams(1,10,10,new ArrayList<Course>());
+        assertEquals(params, params);
+    }
+
+    @Test
+    public void test_equalsAnother() throws Exception {
+        SlackSlashCommandParams params1 = new SlackSlashCommandParams(1,10,10,new ArrayList<Course>());
+        SlackSlashCommandParams params2 = new SlackSlashCommandParams(1,10,10,new ArrayList<Course>());
+        assertEquals(params1, params2);
+    }
+
+    @Test
+    public void test_hashCode() throws Exception {
+        SlackSlashCommandParams params1 = new SlackSlashCommandParams(1,10,10,new ArrayList<Course>());
+        SlackSlashCommandParams params2 = new SlackSlashCommandParams(1,10,10,new ArrayList<Course>());
+        assertEquals(params1.hashCode(), params2.hashCode());
+    }
+
+    @Test
+    public void test_toString() throws Exception {
+        SlackSlashCommandParams params1 = new SlackSlashCommandParams(1,10,10,new ArrayList<Course>());
+        assertEquals("{ pageNumber='1', pageSize='10', total='10', classes='[]'}",params1.toString());
+    }
+
+}


### PR DESCRIPTION
In this (for now, draft) PR, we add the basic scaffolding for a slack bot in Mapache Search.

Test coverage still needs to be done.
